### PR TITLE
Docker環境の構築

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# mac metafile
+.DS_Store
+harmovis-provider

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM golang:1.13.0-buster
+
+WORKDIR /go/src
+
+# add apt dependencies 
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+
+# install tools
+RUN apt-get update
+RUN apt-get -y install zip unzip
+
+# install protocol buffers
+RUN curl -OL https://github.com/google/protobuf/releases/download/v3.9.1/protoc-3.9.1-linux-x86_64.zip
+RUN unzip protoc-3.9.1-linux-x86_64.zip -d protoc3
+RUN mv protoc3/bin/* /usr/local/bin/
+RUN mv protoc3/include/* /usr/local/include/
+RUN go get -u github.com/golang/protobuf/protoc-gen-go
+
+# install grpc for golang lib
+RUN go get -u google.golang.org/grpc
+
+# build synerex daemon
+WORKDIR /go/src/github.com/synerex/provider/harmovis
+COPY . .
+RUN sed -i 's/\r//' ./entrypoint.sh
+RUN chmod +x ./entrypoint.sh
+
+EXPOSE 10080
+
+ENTRYPOINT [ "./entrypoint.sh" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3'
+
+services:
+  harmovis_provider:
+    tty: true
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: harmovis_provider
+    volumes:
+      - .:/go/src/github.com/synerex/provider/harmovis
+    ports:
+      - "10080:10080"
+    networks: 
+      - synerex_net
+      - default
+networks:
+  synerex_net:
+    external: true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+go build
+./harmovis-provider -nodesrv nodeserv:9990


### PR DESCRIPTION
### 確認方法  
- Serverとnodeserv, fleet-prviderの環境を先に立ち上げておく
- `docker-compose build`でイメージをビルドする
- `docker-compose up`で実行する
- `http://localhost:10080`にアクセスしてViewerが見れる事

### 変更点 
- Dockerfile, docker-compose.yml, entrypoint.shの追加
